### PR TITLE
feat: add Ctrl+Tab and Ctrl+Shift+Tab shortcuts for tab navigation

### DIFF
--- a/resources/js/events.js
+++ b/resources/js/events.js
@@ -202,6 +202,10 @@ function _bindGlobalShortcuts() {
     if (e.ctrlKey && e.key === 's')  { e.preventDefault(); saveCurrentFile(); }
     if (e.ctrlKey && e.key === 'n')  { e.preventDefault(); newFileInRoot(); }
     if (e.ctrlKey && e.key === 'w')  { e.preventDefault(); if (state.activeTabPath) closeTab(state.activeTabPath); }
+		if (e.ctrlKey && e.key === 'Tab') {
+      e.preventDefault();
+      cycleTabs(e.shiftKey ? 'prev' : 'next');
+    }
     if (e.ctrlKey && e.key === '`')  { e.preventDefault(); toggleTerminal(); }
     if (e.ctrlKey && e.key === 'f' && !editor?.hasFocus()) { e.preventDefault(); openFindBar(false); }
     if (e.ctrlKey && e.key === 'h' && !editor?.hasFocus()) { e.preventDefault(); openFindBar(true);  }

--- a/resources/js/tabs.js
+++ b/resources/js/tabs.js
@@ -74,3 +74,20 @@ function markTabModified(filePath, modified) {
   const tab = state.openTabs.find(t => t.path === filePath);
   if (tab) { tab.modified = modified; renderTabs(); }
 }
+
+function cycleTabs(direction) {
+  if (state.openTabs.length <= 1) return;
+
+  const currentIndex = state.openTabs.findIndex(t => t.path === state.activeTabPath);
+  let nextIndex;
+
+  if (direction === 'next') {
+    nextIndex = (currentIndex + 1) % state.openTabs.length;
+  } else {
+    nextIndex = (currentIndex - 1 + state.openTabs.length) % state.openTabs.length;
+  }
+
+  const nextTab = state.openTabs[nextIndex];
+  setActiveTab(nextTab.path);
+  loadEditorContent(nextTab.path, nextTab.name);
+}


### PR DESCRIPTION
## Overview
This PR implements keyboard navigation for open tabs, bringing the experience closer to standard IDE behaviors. 

## Changes
- **tabs.js**: Implemented `cycleTabs(direction)` to handle circular navigation using the global `state.openTabs` array.
- **events.js**: Added handlers for `Ctrl+Tab` (next) and `Ctrl+Shift+Tab` (previous) within `_bindGlobalShortcuts`.
- **UX**: Added `e.preventDefault()` to ensure smooth switching and prevent browser focus-trapping.

## How to Test
1. Open multiple files.
2. Press `Ctrl+Tab` to move forward.
3. Press `Ctrl+Shift+Tab` to move backward.
4. Verify that the editor content, breadcrumbs, and sidebar highlights update correctly.

## Related Issues
Closes #14